### PR TITLE
Add installed version guard with force override

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -17,6 +17,8 @@ Ce qui est fait
    détectés dans `plugins/`).
 3. README mis à jour pour documenter l’usage, le fonctionnement de l’archive
    minimale et la suppression des fichiers obsolètes.
+4. Le script détecte maintenant la version CRS installée et ignore les mises à jour
+   redondantes, avec la possibilité de forcer l’exécution via `--force`.
 
 À faire (lorsque tu reprendras)
 -------------------------------

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Why this tool?
   files, custom plugins, and user-defined glob patterns.
 - **Minimal archive first** – prefers the official `coreruleset-<version>-minimal.tar.gz`
   asset but falls back to the full bundle when needed.
+- **Idempotent runs** – detects the installed CRS version and skips redundant updates (use `--force` to override).
 - **Practical automation** – optional cache, backup retention, and Nginx reload flag.
 
 Quick start (server side)
@@ -83,6 +84,7 @@ Options
 | `--asset-suffix <suffix>` | Override the archive suffix (default `-minimal`; pass empty string for full bundle only). |
 | `--cache-dir <dir>` | Override the download cache directory. |
 | `--reload-nginx` | Reload Nginx after a successful update (`systemctl reload` → `nginx -s reload`). |
+| `-f, --force` | Force the update even when the detected CRS version already matches the target. |
 
 Best practices
 --------------


### PR DESCRIPTION
## Summary
- detect installed CRS version before attempting an update
- add --force flag to override the guard and document the behaviour
- update progress log with the new idempotent flow for CRS updates

## Testing
- ./update_crs_inplace.sh --version 4.16.0 --base-dir "${PWD}/etc/modsecurity/crs4" --skip-verify --no-test